### PR TITLE
Добавление конфигурации для kafka

### DIFF
--- a/excelMicroservice/pom.xml
+++ b/excelMicroservice/pom.xml
@@ -65,6 +65,10 @@
 			<artifactId>modelmapper</artifactId>
 			<version>${modelmapper.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/excelMicroservice/src/main/java/com/shirayev/excel/processing/client/microservice/StatisticsKafkaTransferDataClient.java
+++ b/excelMicroservice/src/main/java/com/shirayev/excel/processing/client/microservice/StatisticsKafkaTransferDataClient.java
@@ -1,0 +1,2 @@
+package com.shirayev.excel.processing.client.microservice;public class StatisticsKafkaTransferDataClient {
+}

--- a/excelMicroservice/src/main/java/com/shirayev/excel/processing/client/microservice/StatisticsKafkaTransferDataClient.java
+++ b/excelMicroservice/src/main/java/com/shirayev/excel/processing/client/microservice/StatisticsKafkaTransferDataClient.java
@@ -1,2 +1,35 @@
-package com.shirayev.excel.processing.client.microservice;public class StatisticsKafkaTransferDataClient {
+package com.shirayev.excel.processing.client.microservice;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StatisticsKafkaTransferDataClient<T> implements TransferDataClient<T> {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    private final NewTopic topicSaveFileStatistics;
+
+    @Override
+    public T transferData(Object body) {
+        CompletableFuture<SendResult<String, Object>> future = kafkaTemplate.send(topicSaveFileStatistics.name(), body);
+
+        future.whenComplete((result, throwable) -> {
+            if(throwable != null) {
+                log.warn("Message was not sent. Error: {}", throwable.getMessage());
+            } else {
+                log.info("Sent message: {}, with offset: {}", body, result.getRecordMetadata().offset());
+            }
+        });
+
+        return (T) body;
+    }
 }

--- a/excelMicroservice/src/main/java/com/shirayev/excel/processing/client/microservice/StatisticsTransferDataClient.java
+++ b/excelMicroservice/src/main/java/com/shirayev/excel/processing/client/microservice/StatisticsTransferDataClient.java
@@ -1,26 +1,30 @@
 package com.shirayev.excel.processing.client.microservice;
 
+import com.shirayev.excel.processing.client.microservice.builder.BuilderStatisticsTransfer;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestOperations;
 
 import java.net.URI;
 
-@Configuration
+@Data
+@Component
 @RequiredArgsConstructor
-@Qualifier("statisticsTransfer")
 public class StatisticsTransferDataClient<T> implements TransferDataClient<T> {
 
     private final RestOperations restTemplate;
 
+    private BuilderStatisticsTransfer<T> builderStatisticsTransfer;
+
     @Override
-    public T transferData(URI uri, Object body, Class<T> clazz) {
-        return restTemplate.exchange(uri,
+    public T transferData(Object body) {
+        return restTemplate.exchange(builderStatisticsTransfer.getUri(),
                 HttpMethod.POST,
                 new HttpEntity<>(body),
-                clazz).getBody();
+                builderStatisticsTransfer.getClazz()).getBody();
     }
 }

--- a/excelMicroservice/src/main/java/com/shirayev/excel/processing/client/microservice/TransferDataClient.java
+++ b/excelMicroservice/src/main/java/com/shirayev/excel/processing/client/microservice/TransferDataClient.java
@@ -4,6 +4,7 @@ import java.net.URI;
 
 public interface TransferDataClient<T> {
 
-    T transferData(URI uri, Object body, Class<T> clazz);
+    T transferData(Object body);
+
 
 }

--- a/excelMicroservice/src/main/java/com/shirayev/excel/processing/client/microservice/builder/BuilderStatisticsTransfer.java
+++ b/excelMicroservice/src/main/java/com/shirayev/excel/processing/client/microservice/builder/BuilderStatisticsTransfer.java
@@ -1,2 +1,19 @@
-package com.shirayev.excel.processing.client.microservice.builder;public class BuilderStatisticsTransfer {
+package com.shirayev.excel.processing.client.microservice.builder;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.net.URI;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BuilderStatisticsTransfer<T> {
+
+    private URI uri;
+
+    private Class<T> clazz;
 }

--- a/excelMicroservice/src/main/java/com/shirayev/excel/processing/client/microservice/builder/BuilderStatisticsTransfer.java
+++ b/excelMicroservice/src/main/java/com/shirayev/excel/processing/client/microservice/builder/BuilderStatisticsTransfer.java
@@ -1,0 +1,2 @@
+package com.shirayev.excel.processing.client.microservice.builder;public class BuilderStatisticsTransfer {
+}

--- a/excelMicroservice/src/main/java/com/shirayev/excel/processing/client/statistics/StatisticsClient.java
+++ b/excelMicroservice/src/main/java/com/shirayev/excel/processing/client/statistics/StatisticsClient.java
@@ -2,7 +2,6 @@ package com.shirayev.excel.processing.client.statistics;
 
 import com.shirayev.excel.processing.client.microservice.TransferDataClient;
 import com.shirayev.excel.processing.dto.FileDto;
-import com.shirayev.excel.processing.client.microservice.uri.URIBuilder;
 import com.shirayev.excel.processing.dto.FileNesting;
 import com.shirayev.excel.processing.entities.File;
 import lombok.RequiredArgsConstructor;
@@ -17,9 +16,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class StatisticsClient implements IStatisticsClient{
 
-    private final URIBuilder uriStatistics;
-
-    private final TransferDataClient<FileDto> statisticsTransfer;
+    private final TransferDataClient<FileDto> statisticsKafkaTransferDataClient;
 
     private final ModelMapper model;
 
@@ -29,9 +26,8 @@ public class StatisticsClient implements IStatisticsClient{
 
         log.info("Send writing file with id: {} in microservice statistics", file.getId());
 
-        statisticsTransfer.transferData(uriStatistics.createURI("/save"),
-                model.map(file, FileNesting.class),
-                FileDto.class
+        statisticsKafkaTransferDataClient.transferData(
+                model.map(file, FileNesting.class)
         );
     }
 

--- a/excelMicroservice/src/main/java/com/shirayev/excel/processing/config/kafka/KafkaProducerConfig.java
+++ b/excelMicroservice/src/main/java/com/shirayev/excel/processing/config/kafka/KafkaProducerConfig.java
@@ -1,0 +1,36 @@
+package com.shirayev.excel.processing.config.kafka;
+
+import com.shirayev.excel.processing.dto.FileNesting;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value(value = "${spring.kafka.bootstrap-servers}")
+    private String kafkaAddress;
+
+    private ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> configuration = Map.of(
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaAddress,
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class,
+                JsonSerializer.TYPE_MAPPINGS, String.format("fileNesting:%s", FileNesting.class.getCanonicalName())
+        );
+        return new DefaultKafkaProducerFactory<>(configuration);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/excelMicroservice/src/main/java/com/shirayev/excel/processing/config/kafka/KafkaTopicConfig.java
+++ b/excelMicroservice/src/main/java/com/shirayev/excel/processing/config/kafka/KafkaTopicConfig.java
@@ -16,7 +16,7 @@ public class KafkaTopicConfig {
     private String kafkaAddress;
 
     @Value(value = "${spring.kafka.topics.statistics.save-file}")
-    private String statisticsSaveTopic;
+    private String statisticsSaveFileTopic;
 
     @Bean
     public KafkaAdmin kafkaAdmin() {
@@ -27,8 +27,8 @@ public class KafkaTopicConfig {
     }
 
     @Bean
-    public NewTopic topicStatistics() {
-        return new NewTopic(statisticsSaveTopic, 1, (short) 1);
+    public NewTopic topicSaveFileStatistics() {
+        return new NewTopic(statisticsSaveFileTopic, 1, (short) 1);
     }
 
 }

--- a/excelMicroservice/src/main/java/com/shirayev/excel/processing/config/kafka/KafkaTopicConfig.java
+++ b/excelMicroservice/src/main/java/com/shirayev/excel/processing/config/kafka/KafkaTopicConfig.java
@@ -1,0 +1,34 @@
+package com.shirayev.excel.processing.config.kafka;
+
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaAdmin;
+
+import java.util.Map;
+
+@Configuration
+public class KafkaTopicConfig {
+
+    @Value(value = "${spring.kafka.bootstrap-servers}")
+    private String kafkaAddress;
+
+    @Value(value = "${spring.kafka.topics.statistics.save-file}")
+    private String statisticsSaveTopic;
+
+    @Bean
+    public KafkaAdmin kafkaAdmin() {
+        Map<String, Object> configuration = Map.of(
+                AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaAddress
+        );
+        return new KafkaAdmin(configuration);
+    }
+
+    @Bean
+    public NewTopic topicStatistics() {
+        return new NewTopic(statisticsSaveTopic, 1, (short) 1);
+    }
+
+}

--- a/excelMicroservice/src/main/resources/application.yaml
+++ b/excelMicroservice/src/main/resources/application.yaml
@@ -22,3 +22,9 @@ spring:
   liquibase:
     enabled: true
     change-log: classpath:db/changelog.xml
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    topics:
+      statistics:
+        save-file: statistics-save-file

--- a/statisticsPeoplePassage/pom.xml
+++ b/statisticsPeoplePassage/pom.xml
@@ -55,6 +55,10 @@
 			<artifactId>modelmapper</artifactId>
 			<version>${modelmapper.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/statisticsPeoplePassage/src/main/java/com/shirayev/statistics/people/passage/config/kafka/KafkaConsumerConfig.java
+++ b/statisticsPeoplePassage/src/main/java/com/shirayev/statistics/people/passage/config/kafka/KafkaConsumerConfig.java
@@ -1,0 +1,49 @@
+package com.shirayev.statistics.people.passage.config.kafka;
+
+
+import com.shirayev.statistics.people.passage.dto.FileNesting;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value(value = "${spring.kafka.bootstrap-servers}")
+    private String kafkaAddress;
+
+    @Value(value = "${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    @Value(value = "${spring.kafka.consumer.auto-offset-reset}")
+    private String autoOffsetReset;
+
+    private ConsumerFactory<String, Object> consumerFactory() {
+        Map<String, Object> configuration = Map.of(
+                ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaAddress,
+                ConsumerConfig.GROUP_ID_CONFIG, groupId,
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class,
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset,
+                JsonDeserializer.TYPE_MAPPINGS, String.format("fileNesting:%s", FileNesting.class.getCanonicalName())
+        );
+        return new DefaultKafkaConsumerFactory<>(configuration);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/statisticsPeoplePassage/src/main/java/com/shirayev/statistics/people/passage/config/kafka/KafkaTopicConfig.java
+++ b/statisticsPeoplePassage/src/main/java/com/shirayev/statistics/people/passage/config/kafka/KafkaTopicConfig.java
@@ -1,0 +1,34 @@
+package com.shirayev.statistics.people.passage.config.kafka;
+
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaAdmin;
+
+import java.util.Map;
+
+@Configuration
+public class KafkaTopicConfig {
+
+    @Value(value = "${spring.kafka.bootstrap-servers}")
+    private String kafkaAddress;
+
+    @Value(value = "${spring.kafka.topics.statistics.save-file}")
+    private String statisticsSaveTopic;
+
+    @Bean
+    public KafkaAdmin kafkaAdmin() {
+        Map<String, Object> configuration = Map.of(
+                AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaAddress
+        );
+        return new KafkaAdmin(configuration);
+    }
+
+    @Bean
+    public NewTopic topicStatisticsSaveFile() {
+        return new NewTopic(statisticsSaveTopic, 1, (short) 1);
+    }
+
+}

--- a/statisticsPeoplePassage/src/main/java/com/shirayev/statistics/people/passage/servicies/implementation/FileService.java
+++ b/statisticsPeoplePassage/src/main/java/com/shirayev/statistics/people/passage/servicies/implementation/FileService.java
@@ -10,7 +10,6 @@ import com.shirayev.statistics.people.passage.entities.Sheets;
 import com.shirayev.statistics.people.passage.repositories.FileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.modelmapper.ModelMapper;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Service;
@@ -49,7 +48,7 @@ public class FileService implements IFileService {
 
         log.info("Save sheets in file");
 
-        sheetsService.updateAndInsertOfData(mapperClazz.getListObject(fileNesting.getSheets(), SheetsDto.class), model.map(fileDto, File.class));
+        sheetsService.updateAndInsertOfData(mapperClazz.getListObject(fileNesting.getSheets(), SheetsDto.class), mapperClazz.getObject(fileDto, File.class));
 
         log.info("Save statistics_people_passage in sheets");
 

--- a/statisticsPeoplePassage/src/main/java/com/shirayev/statistics/people/passage/servicies/implementation/FileService.java
+++ b/statisticsPeoplePassage/src/main/java/com/shirayev/statistics/people/passage/servicies/implementation/FileService.java
@@ -26,8 +26,6 @@ public class FileService implements IFileService {
 
     private final FileRepository fileRepository;
 
-    private final ModelMapper model;
-
     private final SheetsService sheetsService;
 
     private final StatisticsPeoplePassageService statisticsPeoplePassageService;
@@ -47,7 +45,7 @@ public class FileService implements IFileService {
 
         log.info("Save file with id: {}", fileNesting.getId());
 
-        FileDto fileDto = save(model.map(fileNesting, FileDto.class));
+        FileDto fileDto = save(mapperClazz.getObject(fileNesting, FileDto.class));
 
         log.info("Save sheets in file");
 
@@ -57,7 +55,7 @@ public class FileService implements IFileService {
 
         fileNesting.getSheets().forEach(sheet -> statisticsPeoplePassageService.updateAndInsertOfData(
                 sheet.getPeoplePassages(),
-                model.map(sheet, Sheets.class)
+                mapperClazz.getObject(sheet, Sheets.class)
         ));
 
         return fileDto;
@@ -65,7 +63,7 @@ public class FileService implements IFileService {
 
     @Override
     public FileDto save(FileDto fileDto) {
-        return model.map(fileRepository.save(model.map(fileDto, File.class)), FileDto.class);
+        return mapperClazz.getObject(fileRepository.save(mapperClazz.getObject(fileDto, File.class)), FileDto.class);
     }
 
 }

--- a/statisticsPeoplePassage/src/main/resources/application.yaml
+++ b/statisticsPeoplePassage/src/main/resources/application.yaml
@@ -31,7 +31,7 @@ spring:
     bootstrap-servers: localhost:9092
     consumer:
       auto-offset-reset: earliest
-      group-id:
+      group-id: statistics-save
     topics:
       statistics:
         save-file: statistics-save-file

--- a/statisticsPeoplePassage/src/main/resources/application.yaml
+++ b/statisticsPeoplePassage/src/main/resources/application.yaml
@@ -26,3 +26,12 @@ spring:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     generate-ddl: true
     show-sql: true
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      auto-offset-reset: earliest
+      group-id:
+    topics:
+      statistics:
+        save-file: statistics-save-file


### PR DESCRIPTION
- Добавление классов конфигурации для Topic, Producer и Consumer. Данные классы находятся в *.config.kafka в обоих сервисах  
- Добавление конфигурации kafka в файлы application.yml
- Изменение сигнатуры методы в интерфейсе TransferDataClient, а также изменение реализации StatisticsTransferDataClient, и добавление реализации данного интерфейса класса StatisticsKafkaTransferDataClient
- Добавление слушателя события в сервисе statistics в FileService над методом saveNesting(FileNesting fileNesting)